### PR TITLE
fix: wrong analytics url hosting on subpath

### DIFF
--- a/packages/blog-starter-kit/themes/enterprise/components/analytics.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/analytics.tsx
@@ -159,14 +159,14 @@ export const Analytics = () => {
 		let hasSentBeacon = false;
 		try {
 			if (navigator.sendBeacon) {
-				hasSentBeacon = navigator.sendBeacon(`/api/analytics`, blob);
+				hasSentBeacon = navigator.sendBeacon(`${BASE_PATH}/api/analytics`, blob);
 			}
 		} catch (error) {
 			// do nothing; in case there is an error we fall back to fetch
 		}
 
 		if (!hasSentBeacon) {
-			fetch(`/api/analytics`, {
+			fetch(`${BASE_PATH}/api/analytics`, {
 				method: 'POST',
 				body: blob,
 				credentials: 'omit',


### PR DESCRIPTION
Sending to a relative URL only works if the blog is hosted on the root path. Adding the `BASE_PATH` to the URL makes the analytics request URL absolute which also works if the blog is hosted on a subpath (like `/blog` in your case).

I assume that your `NEXT_PUBLIC_BASE_URL` environment variable is set to `https://mindsdb.com/blog` in your case.